### PR TITLE
Handle "R" node refresh

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -172,7 +172,7 @@ def get_files(server, port) -> ModelsInfo:
                 'remacri_4x_f16.ckpt',
                 '4x_ultrasharp_f16.ckpt',
             ]
-            model_info['upscalers'] = [[UpscalerInfo(file=f, name=f) for f in official if f in DrawThingsSampler.files_list]]
+            model_info['upscalers'] = [UpscalerInfo(file=f, name=f) for f in official if f in DrawThingsSampler.files_list]
 
         return model_info
 

--- a/web/js/ComfyUI-DrawThings-gRPC.js
+++ b/web/js/ComfyUI-DrawThings-gRPC.js
@@ -30,7 +30,7 @@ app.registerExtension({
     },
     async nodeCreated(node) {
         if (DrawThingsNodeTypes.includes(node?.comfyClass)) {
-            if (node.id !== -1) updateNodeModels(node);
+            updateNodeModels(node);
         }
         if (node?.comfyClass === "DrawThingsSampler") {
             console.debug("nodeCreated(DrawThingsSampler)", node);
@@ -71,8 +71,10 @@ app.registerExtension({
         }
     },
     async loadedGraphNode(node) {
-        if (node?.comfyClass === "DrawThingsSampler") {
-            console.debug("loadedGraphNode(DrawThingsSampler)", node);
+        if (
+            DrawThingsNodeTypes.includes(node?.comfyClass) &&
+            node?.isDtRootNode
+        ) {
             updateNodeModels(node);
         }
     },
@@ -111,6 +113,14 @@ app.registerExtension({
                         return r;
                     };
                 }
+            }
+        }
+    },
+    refreshComboInNodes(defs, app) {
+        for (const type of DrawThingsNodeTypes) {
+            for (const node of app.graph.findNodesByType(type)) {
+                if (node.widgets.some((w) => w.options.values === "DT_MODEL"))
+                    updateNodeModels(node, true);
             }
         }
     },


### PR DESCRIPTION
Fixed a bug where pressing R to refresh the node definitions set the model options to "D, T, _, M, O, D, E, L"