### PR TITLE
Dev

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ grpcio>=1.71.0
 flatbuffers>=25.2.10
 protobuf>=5.29.0
 typing_extensions>=4.12.2
+fpzip

--- a/src/draw_things.py
+++ b/src/draw_things.py
@@ -132,6 +132,19 @@ async def dt_sampler(inputs: dict):
 
             # hint images might be batched, so check for multiple images and add each
             for i in range(hint_images.size(dim=0)):
+                if config.hiresFix:
+                    hint_tensor = convert_image_for_request(
+                        hint_images,
+                        hint_type,
+                        batch_index=i,
+                        width=config.hiresFixStartWidth,
+                        height=config.hiresFixStartHeight,
+                    )
+                    taw = imageService_pb2.TensorAndWeight()
+                    taw.weight = 1
+                    taw.tensor = hint_tensor
+                    taws.append(taw)
+
                 hint_tensor = convert_image_for_request(
                     hint_images,
                     hint_type,
@@ -143,6 +156,7 @@ async def dt_sampler(inputs: dict):
                 taw.weight = 1
                 taw.tensor = hint_tensor
                 taws.append(taw)
+
 
         hp = imageService_pb2.HintProto()
         hp.hintType = hint_type

--- a/src/draw_things.py
+++ b/src/draw_things.py
@@ -137,8 +137,8 @@ async def dt_sampler(inputs: dict):
                         hint_images,
                         hint_type,
                         batch_index=i,
-                        width=config.hiresFixStartWidth,
-                        height=config.hiresFixStartHeight,
+                        width=config.hiresFixStartWidth * 64,
+                        height=config.hiresFixStartHeight * 64,
                     )
                     taw = imageService_pb2.TensorAndWeight()
                     taw.weight = 1
@@ -157,11 +157,11 @@ async def dt_sampler(inputs: dict):
                 taw.tensor = hint_tensor
                 taws.append(taw)
 
-
-        hp = imageService_pb2.HintProto()
-        hp.hintType = hint_type
-        hp.tensors.extend(taws)
-        req_hints.append(hp)
+        if len(taws) > 0:
+            hp = imageService_pb2.HintProto()
+            hp.hintType = hint_type
+            hp.tensors.extend(taws)
+            req_hints.append(hp)
 
     progress = comfy.utils.ProgressBar(config.steps, inputs["unique_id"])
 

--- a/src/nodes.py
+++ b/src/nodes.py
@@ -129,6 +129,11 @@ class DrawThingsSampler:
     CATEGORY = "DrawThings"
 
     async def sample(self, **kwargs):
+        try:
+            await get_files(kwargs["server"], kwargs["port"], kwargs["use_tls"])
+        except:
+            raise Exception("Couldn't connect to Draw Things gRPC server. Check your server and settings, and try again.")
+
         DrawThingsSampler.last_gen_canceled = False
         model_input = kwargs.get("model")
         if type(model_input) is not dict:
@@ -163,15 +168,7 @@ class DrawThingsSampler:
         return hash(items)
 
     @classmethod
-    async def VALIDATE_INPUTS(cls, server, port, use_tls):
-        try:
-            await get_files(server, port, use_tls)
-        except:
-            raise Exception("No connection to Draw Things gRPC. Double check your settings and server, and try again.")
-        # PromptServer.instance.send_sync("dt-grpc-validate", dict({"hello": "js"}))
-        # if model.get("value") is None or model.get("value").get("file") is None:
-        #     raise Exception("Please select a model")
-        # print(model)
+    async def VALIDATE_INPUTS(cls):
         return True
 
 

--- a/src/nodes.py
+++ b/src/nodes.py
@@ -8,7 +8,7 @@ import grpc
 from torchvision.transforms import v2
 
 from .. import cancel_request
-from .draw_things import dt_sampler
+from .draw_things import dt_sampler, get_files
 from .data_types import *
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy"))
@@ -163,7 +163,11 @@ class DrawThingsSampler:
         return hash(items)
 
     @classmethod
-    def VALIDATE_INPUTS(cls):
+    async def VALIDATE_INPUTS(cls, server, port, use_tls):
+        try:
+            await get_files(server, port, use_tls)
+        except:
+            raise Exception("No connection to Draw Things gRPC. Double check your settings and server, and try again.")
         # PromptServer.instance.send_sync("dt-grpc-validate", dict({"hello": "js"}))
         # if model.get("value") is None or model.get("value").get("file") is None:
         #     raise Exception("Please select a model")

--- a/web/dtModelNodes.js
+++ b/web/dtModelNodes.js
@@ -121,7 +121,7 @@ const dtServerNodeProto = {
             if (models === null) {
                 widget.options.values = ["Not connected", "Click to retry"]
                 widget.value = "Not connected"
-                return
+                continue
             }
 
             widget.options.values = ["(None selected)", ...models.models.map(m => getMenuItem(m)).sort((a, b) => a.content.localeCompare(b.content))]
@@ -166,7 +166,7 @@ const dtModelStandardNodeProto = {
             if (!models[type]) {
                 widget.options.values = ["Not connected", "Click to retry"]
                 widget.value = "Not connected"
-                return
+                continue
             }
 
             widget.options.values = ["(None selected)", ...models[type]
@@ -180,6 +180,16 @@ const dtModelStandardNodeProto = {
             if (widget.value === "Click to retry" || widget.value === "Not connected") {
                 if (this._lastSelectedModel?.[widget.name]) widget.value = fixLabel(this._lastSelectedModel[widget.name])
                 else widget.value = "(None selected)"
+            }
+
+            if (widget.value?.toString() === "[object Object]") {
+                const value = {
+                    ...widget.value,
+                    toString() {
+                        return this.value.name
+                    },
+                }
+                widget.value = value
             }
         }
     }

--- a/web/upgrade.js
+++ b/web/upgrade.js
@@ -5,32 +5,35 @@ const app = App.app
 
 const dataPath = "./drawthings-grpc/data.json"
 
-export async function checkVersion(currentVersion) {
-    const lastVersion = await getLastUsedVersion()
-    if (lastVersion === null || lastVersion !== currentVersion) {
-        await setLastUsedVersion(currentVersion)
+export async function checkVersion() {
+    // instead of doing it like this, we're going to...
+    // - only consider the latest version
+    // - record the version numbers that have been announced
+    // - if the latest announcement isn't in the lsit of versions, show it and record
+    const announced = await getAnnounced()
+    const latestAnnouncement = announcements[announcements.length - 1]
+    if (!announced.includes(latestAnnouncement.version)) {
+        await saveAnnounced(latestAnnouncement.version)
 
-        for (const announcement of announcements) {
-            if (compareVersions(currentVersion, announcement.version) < 0) continue
-            app.extensionManager.toast.add({
-                summary: announcement.title,
-                detail: announcement.detail,
-                severity: 'success',
-                life: 0
-            })
-        }
-
+        app.extensionManager.toast.add({
+            summary: latestAnnouncement.title,
+            detail: latestAnnouncement.detail,
+            severity: 'success',
+            life: 0
+        })
     }
 }
 
-async function getLastUsedVersion() {
+async function getAnnounced() {
     const data = await getUserData()
-    return data.lastUsedVersion
+    return data?.announced ?? []
 }
 
-async function setLastUsedVersion(version) {
+async function saveAnnounced(version) {
     const data = await getUserData()
-    data.lastUsedVersion = version
+    if (!data?.announced || !Array.isArray(data?.announced))
+        data.announced = []
+    data.announced.push(version)
     await app.api.storeUserData(dataPath, data)
 }
 
@@ -48,6 +51,7 @@ async function getUserData() {
 
     const data = {
         lastUsedVersion: null,
+        announced: []
     }
     await app.api.storeUserData(dataPath, data)
     return data
@@ -67,6 +71,20 @@ const announcements = [
             `"Shuffle (Moodboard)" as the hint type.`,
             `\n\nNote: Currently pose or scribble images are not working correctly, but depth or`,
             `moodboard images should work as expected.`].join(' ')
+    },
+    {
+        version: "1.6.4",
+        title: "DrawThings-gRPC 1.6.4",
+        detail: [
+            `- Response compression is now supported! It's no longer necessary to disable this option in Draw Things or the gRPC CLI.`,
+            `- Added hi res fix support for hint images`,
+            `- Add support for pose hint images`,
+            `- Fix: Model widgets should no longer show[object Object] when loading a workflow while disconnected`,
+            `- Fix: The Draw Things Sampler Node now shows the correct error when running a workflow while not connected.`,
+            `- Fix: Hint images are provided in both sizes when HiResFix is enabled`,
+            `- Fix: When loading a workflow while disconnected, the widgets for the last selected model version will be shown.`,
+            `- Fix: Update notes messages should only appear once`,
+        ].join('\n')
     }
 ]
 

--- a/web/widgets.js
+++ b/web/widgets.js
@@ -139,7 +139,7 @@ function showWidgets(node, show, ...widgetNames) {
 
 function updateSamplerWidgets(node) {
     const selectedModel = findWidgetByName(node, "model")?.value;
-    const version = selectedModel?.value?.version ?? "none";
+    const version = selectedModel?.value?.version ?? node?._lastSelectedModel?.model?.value?.version;
 
     const settings = findWidgetByName(node, "settings")?.value;
     const isBasic = settings === "Basic" || settings === "All";


### PR DESCRIPTION
- Response compression is now supported! It's no longer necessary to disable this option in Draw Things or the gRPC CLI.
- Added hi res fix support for hint images
- Add support for pose hint images
- Fix: Model widgets should no longer show [object Object] when loading a workflow while disconnected
- Fix: The Draw Things Sampler Node now shows the correct error when running a workflow while not connected.
- Fix: Hint images are provided in both sizes when HiResFix is enabled
- Fix: When loading a workflow while disconnected, the widgets for the last selected model version will be shown.
- Fix: Update notes messages should only appear once